### PR TITLE
Missing Headers

### DIFF
--- a/udf-sample.cc
+++ b/udf-sample.cc
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include "udf-sample.h"
-#include <math.h>
+
+#include <cctype>
+#include <cmath>
+#include <string>
 
 // In this sample we are declaring a UDF that adds two ints and returns an int.
 IntVal AddUdf(FunctionContext* context, const IntVal& arg1, const IntVal& arg2) {


### PR DESCRIPTION
When trying to compile the UDF example project on a pristine CDH4 system with
Ubuntu 12.04 and the impalae-dev-tools installed, it is not possible to
compile due to missing headers for C-style string manipulations.

This commit adds the headers and replaces the C header with the correct C++
reference.
