### PR TITLE
Performance Evaluation of UDFs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,25 @@
 
 cmake_minimum_required(VERSION 2.6)
 
+# Add Modules from external folder
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/")
+
+# libraries
+set(LINK_LIBRARIES)
+
+
+# PAPI http://icl.cs.utk.edu/papi/index.html is used to get additional
+# information about the expected performance of a UDF. It allows us
+# to count cycles, branches, instructions etc so that we can possibly
+# estimate the performance.
+find_package(PAPI)
+if (PAPI_FOUND)
+  list(APPEND LINK_LIBRARIES ${PAPI_LIBRARIES})
+  include_directories( ${PAPI_INCLUDE_DIR} )
+  add_definitions(-DHAVE_PAPI)
+endif (PAPI_FOUND)
+
+
 # where to put generated libraries
 set(LIBRARY_OUTPUT_PATH "build")
 # where to put generated binaries
@@ -46,9 +65,16 @@ if (CLANG_EXECUTABLE)
   COMPILE_TO_IR(uda-sample.cc )
 endif(CLANG_EXECUTABLE)
 
+# Some Debug Info
+add_definitions("-g -O3")
 # This is an example of how to use the test harness to help develop UDF and UDAs.
 add_executable(udf-sample-test udf-sample-test.cc)
-target_link_libraries(udf-sample-test ImpalaUdf udfsample)
+target_link_libraries(udf-sample-test ImpalaUdf udfsample ${LINK_LIBRARIES})
 add_executable(uda-sample-test uda-sample-test.cc)
-target_link_libraries(uda-sample-test ImpalaUdf udasample)
+target_link_libraries(uda-sample-test ImpalaUdf udasample ${LINK_LIBRARIES})
 
+# Example for adding the Papi lib for building part
+if(PAPI_FOUND)
+  add_executable(udf-sample-test-perf udf-sample-test-perf.cc)
+  target_link_libraries(udf-sample-test-perf ImpalaUdf udfsample ${LINK_LIBRARIES})
+endif(PAPI_FOUND)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,66 @@
-This repo contains sample user defined functions (UDFs) and user defined aggregate functions (UDAs) built against the Impala UDF/UDA framework.
+# Impala Sample UDFs and UDAs
 
-To get started: 
+This repo contains sample user defined functions (UDFs) and user
+defined aggregate functions (UDAs) built against the Impala UDF/UDA
+framework.
+
+## Getting Started
 
 1. Install the impala udf development package: <http://archive.cloudera.com/cdh5/>
 2. cmake .
 3. make
 
-The samples will get built to build/. This contains test executables that you can run locally, without the impala service installed as well as the shared object artifacts that we can run on impala.
+The samples will get built to build/. This contains test executables
+that you can run locally, without the impala service installed as well
+as the shared object artifacts that we can run on impala.
+
+## Evaluating UDFs
+
+Using custom UDFs can incur additional overhead to the query execution
+as they are likely to be executed millions of times. Thus, careful
+optimizations of such functions is required. This sample package
+allows you to quickly evaluate the performance of you UDFs by counting
+instructions and cycles. 
+
+To use performance evaluation, install PAPI for your local platform
+and adapt the following bit of code according to your own UDFs.
+
+    #include "helper/papi-tracer.h"
+    #include "helper/udf-execute.h"
+    
+    // ...
+    impala_udf::UdfExecuteHelper executor;
+    { 
+      ScopedTracer sct("AddUdf", 1000u);
+      for(int i=0; i < sct.numCalls(); ++i) {
+        counter += executor.ExecuteUdf<IntVal, IntVal, IntVal>(
+          AddUdf, IntVal(i), IntVal(i+1)).val;
+      }
+    }
+
+
+The above code will call the UDF `AddUdf` from the sample code 1000
+times and record the cycles and instructions spent. To compile check
+the `CMakeList.txt` for the appropriate target to get all the
+dependencies. Once the binary is built, you can simply execute it. The
+output of the program should now contain something like this:
+
+    --------------------------------------
+    Performance Analysis for AddUdf
+    Real Time:                 0
+    Total Instructions:        64
+    Instructions / Cycle:        2.53008
+    Cycles / Call:             25
+    Time in s per 10^9 calls @3GhZ: 8
+    Time in s per 10^9 calls @2GhZ: 12
+
+This overview tells you how many instructions were executed per call,
+what the ratio between instructions and cycles is, and most
+importantly what the runtime probably will be when the UDF is execute
+1B times.
+
+Two things are very important for optimizing UDF code: the ratio of
+instructions per cycle should be as high as possible (on modern Intel
+platforms the theoretical limit is 4). In addition the number of
+instructions should be as low as possible. Both measures determine
+together the overall execution time.

--- a/cmake_modules/FindPAPI.cmake
+++ b/cmake_modules/FindPAPI.cmake
@@ -1,0 +1,45 @@
+# Try to find PAPI headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(PAPI)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PAPI_PREFIX         Set this variable to the root installation of
+#                      libpapi if the module has problems finding the
+#                      proper installation path.
+#
+# Variables defined by this module:
+#
+#  PAPI_FOUND              System has PAPI libraries and headers
+#  PAPI_LIBRARIES          The PAPI library
+#  PAPI_INCLUDE_DIRS       The location of PAPI headers
+
+find_path(PAPI_PREFIX
+    NAMES include/papi.h
+)
+
+find_library(PAPI_LIBRARIES
+    # Pick the static library first for easier run-time linking.
+    NAMES libpapi.a papi
+    HINTS ${PAPI_PREFIX}/lib ${HILTIDEPS}/lib
+)
+
+find_path(PAPI_INCLUDE_DIRS
+    NAMES papi.h
+    HINTS ${PAPI_PREFIX}/include ${HILTIDEPS}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PAPI DEFAULT_MSG
+    PAPI_LIBRARIES
+    PAPI_INCLUDE_DIRS
+)
+
+mark_as_advanced(
+    PAPI_PREFIX_DIRS
+    PAPI_LIBRARIES
+    PAPI_INCLUDE_DIRS
+)

--- a/helper/papi-tracer.h
+++ b/helper/papi-tracer.h
@@ -1,0 +1,119 @@
+#ifndef PAPI_TRACER_H
+#define PAPI_TRACER_H
+
+#ifdef HAVE_PAPI
+
+#include <papi.h>
+
+#include <iostream>
+#include <stdexcept>
+
+
+// This class provides very simple tracing and printing mechanisms to
+// analyze the performance of a certain piece of code. Currently, the
+// tracer only captures number of instructions and cycles.
+class Tracer {
+
+  int _eventset[2];;
+
+  // Real time
+  float _rtime;
+
+  // Instructions
+  long long _ins;
+
+  // Cycles
+  long long _cyc;
+
+  // Number of calls to the UDF 
+  int _calls;
+  
+  void handleError(int retval) {
+    if (retval != PAPI_OK) {
+      throw std::runtime_error(PAPI_strerror(retval));
+    }
+  }
+  
+
+public:
+
+   Tracer() :  _rtime(0.0f), _ins(0ll), _cyc(0ll), _calls(1) {
+    int retval = PAPI_library_init( PAPI_VER_CURRENT );
+    if ( retval != PAPI_VER_CURRENT )
+      throw std::runtime_error(std::string("Could not initialize PAPI: ") + PAPI_strerror(retval));
+  }
+
+  // Start the tracing procedure and add the events to the
+  // eventlist. The calls parameter can be used if multiple iterations of a
+  // certain piece of code are tested and this parameter is then used for
+  // normalization of the output.
+  void start(unsigned calls = 1) {
+    _calls = calls;
+    _eventset[0] = PAPI_TOT_CYC;
+    _eventset[1] = PAPI_TOT_INS;
+
+    // Get timers
+    _rtime = PAPI_get_real_usec();
+    handleError(PAPI_start_counters(_eventset, 2));
+  }
+
+  // stop tracing and clear the state
+  void stop() {
+    long long data[2];
+    handleError(PAPI_stop_counters(data, 2));
+
+    _rtime = PAPI_get_real_usec() - _rtime;
+    _ins = data[1];
+    _cyc = data[0];
+  }
+
+  int numCalls() {
+    return _calls;
+  }
+
+
+
+
+  void print() {
+    const PAPI_hw_info_t *hwinfo = PAPI_get_hardware_info();
+
+    std::cout << "Real Time:                 " << (_rtime / _calls) << std::endl;
+    std::cout << "Total Instructions:        " << (_ins / _calls) << std::endl;
+    std::cout << "Instructions / Cycle:        " << (float(_ins) / float(_cyc)) << std::endl;
+    std::cout << "Cycles / Call:             " << (_cyc / _calls) << std::endl;
+    std::cout << "Time in s per 10^9 calls @3GhZ: " << ((_cyc * 1000000000ll) / (3 * 1000000000ll) / _calls) << std::endl;
+    std::cout << "Time in s per 10^9 calls @2GhZ: " << ((_cyc * 1000000000ll) / (2 * 1000000000ll) / _calls) << std::endl;
+  }
+
+};
+
+
+class ScopedTracer {
+  const std::string _msg;
+  Tracer _trc;
+public:
+
+ ScopedTracer(const std::string& msg, int c) : _msg(msg) {
+    _trc.start(c);
+  }
+
+  explicit ScopedTracer(unsigned c) {
+    _trc.start(c);
+  }
+
+  ~ScopedTracer() {
+    _trc.stop();
+    std::cout << "\n--------------------------------------" << std::endl;
+    std::cout << "Performance Analysis for " << _msg << std::endl;
+    _trc.print();
+    std::cout << std::endl;
+  }
+
+  int numCalls() {
+    return _trc.numCalls();
+  }
+
+};
+
+#endif
+#endif // PAPI_TRACER_H

--- a/helper/udf-execute.h
+++ b/helper/udf-execute.h
@@ -1,0 +1,125 @@
+#ifndef UDF_EXECUTE_HELPER_H
+#define UDF_EXECUTE_HELPER_H
+
+#include <boost/function.hpp>
+#include <boost/scoped_ptr.hpp>
+
+#include <impala_udf/udf.h>
+#include <impala_udf/udf-debug.h>
+
+
+namespace impala_udf {
+
+class UdfExecuteHelper {
+
+  boost::scoped_ptr<FunctionContext> context;
+
+ public:
+
+ UdfExecuteHelper() : context(FunctionContext::CreateTestContext()) {}
+
+  template<typename RET>
+  RET ExecuteUdf(boost::function<RET(FunctionContext*)> fn) {
+    return fn(context.get());
+  }
+
+  template<typename RET, typename A1>
+  RET ExecuteUdf(boost::function<RET(FunctionContext*, const A1&)> fn,
+      const A1& a1) {
+    return fn(context.get(), a1);
+  }
+
+  template<typename RET, typename A1>
+  RET ExecuteUdf(boost::function<RET(FunctionContext*, int, const A1*)> fn,
+      const std::vector<A1>& a1) {
+    return fn(context.get(), a1.size(), &a1[0]);
+  }
+
+  template<typename RET, typename A1, typename A2>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&)> fn,
+      const A1& a1, const A2& a2) {
+    return fn(context.get(), a1, a2);
+  }
+
+  template<typename RET, typename A1, typename A2>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, int, const A2*)> fn,
+      const A1& a1, const std::vector<A2>& a2) {
+    return fn(context.get(), a1, a2.size(), &a2[0]);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&)> fn,
+      const A1& a1, const A2& a2, const A3& a3) {
+    return fn(context.get(), a1, a2, a3);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, int, const A3*)> fn,
+      const A1& a1, const A2& a2, const std::vector<A3>& a3) {
+    return fn(context.get(), a1, a2, a3.size(), &a3[0]);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          const A4&)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const A4& a4) {
+    return fn(context.get(), a1, a2, a3, a4);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          int, const A4*)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const std::vector<A4>& a4) {
+    return fn(context.get(), a1, a2, a3, a4.size(), &a4[0]);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4,
+      typename A5>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          const A4&, const A5&)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5) {
+    return fn(context.get(), a1, a2, a3, a4, a5);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4,
+      typename A5, typename A6>
+  RET ExecuteUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          const A4&, const A5&, const A6&)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5,
+      const A6& a6) {
+    return fn(context.get(), a1, a2, a3, a4, a5, a6);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4,
+      typename A5, typename A6, typename A7>
+  RET ValidateUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          const A4&, const A5&, const A6&, const A7&)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5,
+      const A6& a6, const A7& a7) {
+    return fn(context.get(), a1, a2, a3, a4, a5, a6, a7);
+  }
+
+  template<typename RET, typename A1, typename A2, typename A3, typename A4,
+      typename A5, typename A6, typename A7, typename A8>
+  RET ValidateUdf(
+      boost::function<RET(FunctionContext*, const A1&, const A2&, const A3&,
+          const A4&, const A5&, const A6&, const A7&)> fn,
+      const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5,
+      const A6& a6, const A7& a7, const A8& a8, const RET& expected) {
+    return fn(context.get(), a1, a2, a3, a4, a5, a6, a7, a8);
+  }
+};
+
+}
+
+
+#endif // UDF_EXECUTE_HELPER_H

--- a/udf-sample-test-perf.cc
+++ b/udf-sample-test-perf.cc
@@ -1,0 +1,68 @@
+// Copyright 2012 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include <impala_udf/udf-test-harness.h>
+#include "udf-sample.h"
+
+#include "helper/papi-tracer.h"
+#include "helper/udf-execute.h"
+
+int counter = 0;
+
+int main(int argc, char** argv) {
+
+  // Use the ScopedTracer class with the number of iterations and a
+  // descriptions string as constructor arguments to evaluate the
+  // performance. The performance evaluation will not look at the data
+  // side, but not the data processing side. The most reliable numbers
+  // will be the instruction count rather than the cycle count due to
+  // possible instruction cache or data cache misses.
+  impala_udf::UdfExecuteHelper exe;
+  { 
+    ScopedTracer sct("AddUdf", 100000u);
+    for(int i=0; i < sct.numCalls(); ++i) {
+      counter += exe.ExecuteUdf<IntVal, IntVal, IntVal>(
+        AddUdf, IntVal(i), IntVal(i+1)).val;
+    }
+  }
+
+  { 
+    ScopedTracer sct("FuzzyEquals", 1000u);
+    for(int i=0; i < sct.numCalls(); ++i) {
+      counter += exe.ExecuteUdf<BooleanVal, DoubleVal, DoubleVal>(
+      FuzzyEquals, DoubleVal(1.0), DoubleVal(1.0000000001)).val;
+    }
+  }
+
+  // Performance test for string values should use the average number
+  // of characters that are checked. It makes a huge difference for
+  // the performance estimation if the string is longer as the inner
+  // loop of the CountVowels function depends on the input string
+  std::vector<std::string> data;
+  data.push_back("vo910293801981081092wel");
+  data.push_back("nw12312312312312dzl");
+  data.push_back("xszsxsqlwoe");
+		 
+  { 
+    ScopedTracer sct("CountVowels", 1000u);
+    for(int i=0; i < sct.numCalls(); ++i) {
+      counter += exe.ExecuteUdf<IntVal, StringVal>(
+        CountVowels, StringVal(data[i % 3].c_str())).val;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This commit introduces the possibility to evaluate the performance of UDFs using a simple tracing of instructions and cycles. This adds an optional dependency to PAPI. If PAPI is available the make target is build.

Below the text from the README as an entry point for discussions if this makes sense to integrate or not: 

**Evaluating UDFs**

Using custom UDFs can incur additional overhead to the query execution as they are likely to be executed millions of times. Thus, careful optimizations of such functions is required. This sample package  allows you to quickly evaluate the performance of you UDFs by counting instructions and cycles. 

To use performance evaluation, install PAPI for your local platform and adapt the following bit of code according to your own UDFs.

```
#include "helper/papi-tracer.h"
#include "helper/udf-execute.h"

// ...
impala_udf::UdfExecuteHelper executor;
{ 
  ScopedTracer sct("AddUdf", 1000u);
  for(int i=0; i < sct.numCalls(); ++i) {
    counter += executor.ExecuteUdf<IntVal, IntVal, IntVal>(
      AddUdf, IntVal(i), IntVal(i+1)).val;
  }
}
```

The above code will call the UDF `AddUdf` from the sample code 1000 times and record the cycles and instructions spent. To compile check the `CMakeList.txt` for the appropriate target to get all the dependencies. Once the binary is built, you can simply execute it. The output of the program should now contain something like this:

```
--------------------------------------
Performance Analysis for AddUdf
Real Time:                 0
Total Instructions:        64
Instructions / Cycle:        2.53008
Cycles / Call:             25
Time in s per 10^9 calls @3GhZ: 8
Time in s per 10^9 calls @2GhZ: 12
```

This overview tells you how many instructions were executed per call, what the ratio between instructions and cycles is, and most importantly what the runtime probably will be when the UDF is execute 1B times.

Two things are very important for optimizing UDF code: the ratio of instructions per cycle should be as high as possible (on modern Intel platforms the theoretical limit is 4). In addition the number of instructions should be as low as possible. Both measures determine together the overall execution time.
