### PR TITLE
This patch fixes the linker errors while building udf-sample-test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,10 @@ if (CLANG_EXECUTABLE)
 endif(CLANG_EXECUTABLE)
 
 # This is an example of how to use the test harness to help develop UDF and UDAs.
+target_link_libraries(udfsample ImpalaUdf)
+target_link_libraries(udasample ImpalaUdf)
 add_executable(udf-sample-test udf-sample-test.cc)
-target_link_libraries(udf-sample-test ImpalaUdf udfsample)
+target_link_libraries(udf-sample-test udfsample)
 add_executable(uda-sample-test uda-sample-test.cc)
-target_link_libraries(uda-sample-test ImpalaUdf udasample)
+target_link_libraries(uda-sample-test udasample)
 


### PR DESCRIPTION
Currently ImpalaUdf headers aren't linked to udf-sample properly. When building udf-sample-test we see errors like 

build/libudfsample.so: undefined reference to `impala_udf::FunctionContext::GetConstantArg(int) const'
