### PR TITLE
Count example int to bigint.

### DIFF
--- a/uda-sample.cc
+++ b/uda-sample.cc
@@ -43,7 +43,7 @@ void CountInit(FunctionContext* context, BigIntVal* val) {
   val->val = 0;
 }
 
-void CountUpdate(FunctionContext* context, const IntVal& input, BigIntVal* val) {
+void CountUpdate(FunctionContext* context, const BigIntVal& input, BigIntVal* val) {
   if (input.is_null) return;
   ++val->val;
 }

--- a/uda-sample.h
+++ b/uda-sample.h
@@ -42,7 +42,7 @@ using namespace impala_udf;
 //          location '/user/cloudera/libudasample.so' update_fn='CountUpdate';
 //        > select my_count(col) from tbl;
 void CountInit(FunctionContext* context, BigIntVal* val);
-void CountUpdate(FunctionContext* context, const IntVal& input, BigIntVal* val);
+void CountUpdate(FunctionContext* context, const BigIntVal& input, BigIntVal* val);
 void CountMerge(FunctionContext* context, const BigIntVal& src, BigIntVal* dst);
 BigIntVal CountFinalize(FunctionContext* context, const BigIntVal& val);
 


### PR DESCRIPTION
I found that the count example for bigint would not work unless the update function accepted a bigintval, not an intval.