### PR TITLE
Remove spurious const specifiers

### DIFF
--- a/uda-sample.cc
+++ b/uda-sample.cc
@@ -94,7 +94,7 @@ void AvgMerge(FunctionContext* context, const StringVal& src, StringVal* dst) {
 // and free the original allocation. Note that memory allocated by the StringVal ctor is
 // not necessarily persisted across UDA function calls, which is why we don't use it in
 // AvgInit().
-const StringVal AvgSerialize(FunctionContext* context, const StringVal& val) {
+StringVal AvgSerialize(FunctionContext* context, const StringVal& val) {
   assert(!val.is_null);
   StringVal result(context, val.len);
   memcpy(result.ptr, val.ptr, val.len);
@@ -162,7 +162,7 @@ void StringConcatMerge(FunctionContext* context, const StringVal& src, StringVal
 // StringVal, and free the intermediate's memory. Note that memory allocated by the
 // StringVal ctor is not necessarily persisted across UDA function calls, which is why we
 // don't use it in StringConcatUpdate().
-const StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val) {
+StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val) {
   if (val.is_null) return val;
   StringVal result(context, val.len);
   memcpy(result.ptr, val.ptr, val.len);

--- a/uda-sample.h
+++ b/uda-sample.h
@@ -57,7 +57,7 @@ BigIntVal CountFinalize(FunctionContext* context, const BigIntVal& val);
 void AvgInit(FunctionContext* context, StringVal* val);
 void AvgUpdate(FunctionContext* context, const DoubleVal& input, StringVal* val);
 void AvgMerge(FunctionContext* context, const StringVal& src, StringVal* dst);
-const StringVal AvgSerialize(FunctionContext* context, const StringVal& val);
+StringVal AvgSerialize(FunctionContext* context, const StringVal& val);
 StringVal AvgFinalize(FunctionContext* context, const StringVal& val);
 
 // This is a sample of implementing the STRING_CONCAT aggregate function.
@@ -69,7 +69,7 @@ void StringConcatInit(FunctionContext* context, StringVal* val);
 void StringConcatUpdate(FunctionContext* context, const StringVal& arg1,
     const StringVal& arg2, StringVal* val);
 void StringConcatMerge(FunctionContext* context, const StringVal& src, StringVal* dst);
-const StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val);
+StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val);
 StringVal StringConcatFinalize(FunctionContext* context, const StringVal& val);
 
 // This is a example of the variance aggregate function.
@@ -80,7 +80,7 @@ StringVal StringConcatFinalize(FunctionContext* context, const StringVal& val);
 void VarianceInit(FunctionContext* context, StringVal* val);
 void VarianceUpdate(FunctionContext* context, const DoubleVal& input, StringVal* val);
 void VarianceMerge(FunctionContext* context, const StringVal& src, StringVal* dst);
-const StringVal VarianceSerialize(FunctionContext* context, const StringVal& val);
+StringVal VarianceSerialize(FunctionContext* context, const StringVal& val);
 StringVal VarianceFinalize(FunctionContext* context, const StringVal& val);
 
 // An implementation of the Knuth online variance algorithm, which is also single pass and
@@ -92,7 +92,7 @@ StringVal VarianceFinalize(FunctionContext* context, const StringVal& val);
 void KnuthVarianceInit(FunctionContext* context, StringVal* val);
 void KnuthVarianceUpdate(FunctionContext* context, const DoubleVal& input, StringVal* val);
 void KnuthVarianceMerge(FunctionContext* context, const StringVal& src, StringVal* dst);
-const StringVal KnuthVarianceSerialize(FunctionContext* context, const StringVal& val);
+StringVal KnuthVarianceSerialize(FunctionContext* context, const StringVal& val);
 StringVal KnuthVarianceFinalize(FunctionContext* context, const StringVal& val);
 
 // The different steps of the UDA are composable. In this case, we'the UDA will use the

--- a/variance-uda.cc
+++ b/variance-uda.cc
@@ -62,7 +62,7 @@ void VarianceMerge(FunctionContext* ctx, const StringVal& src, StringVal* dst) {
 }
 
 // A serialize function is necessary to free the intermediate state allocation.
-const StringVal VarianceSerialize(FunctionContext* ctx, const StringVal& src) {
+StringVal VarianceSerialize(FunctionContext* ctx, const StringVal& src) {
   StringVal result(ctx, src.len);
   memcpy(result.ptr, src.ptr, src.len);
   ctx->Free(src.ptr);
@@ -117,7 +117,7 @@ void KnuthVarianceMerge(FunctionContext* ctx, const StringVal& src, StringVal* d
 
 // Same as VarianceSerialize(). Create a wrapper function so automatic symbol resolution
 // still works.
-const StringVal KnuthVarianceSerialize(FunctionContext* ctx, const StringVal& state_sv) {
+StringVal KnuthVarianceSerialize(FunctionContext* ctx, const StringVal& state_sv) {
   return VarianceSerialize(ctx, state_sv);
 }
 


### PR DESCRIPTION
This is required to build against more recent versions of the test
harnesses from ASF master