### PR TITLE
Hide symbols by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,15 @@ set(EXECUTABLE_OUTPUT_PATH "build")
 find_program(CLANG_EXECUTABLE clang++)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -ggdb")
+# Hide symbols in UDF code by default - UDF functions should be explicitly exported.
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
 
 # Function to generate rule to cross compile a source file to an IR module.
 # This should be called with the .cc src file and it will generate a
 # src-file-ir target that can be built.
 # e.g. COMPILE_TO_IR(test.cc) generates the "test-ir" make target.
 # Disable compiler optimizations because generated IR is optimized at runtime
-set(IR_COMPILE_FLAGS "-emit-llvm" "-c")
+set(IR_COMPILE_FLAGS "-emit-llvm" "-c" "-fvisibility=hidden" "-fvisibility-inlines-hidden")
 function(COMPILE_TO_IR SRC_FILE)
   get_filename_component(BASE_NAME ${SRC_FILE} NAME_WE)
   set(OUTPUT_FILE "build/${BASE_NAME}.ll")

--- a/common.h
+++ b/common.h
@@ -1,0 +1,26 @@
+// Copyright 2019 Cloudera Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMPALA_UDF_COMMON_H
+#define IMPALA_UDF_COMMON_H
+
+// Macro to prepend to function definitions that will export the
+// symbols to be visible for loading by Impala. This is present in
+// udf.h in some versions of Impala, but we can't assume that it
+// is present yet.
+#ifndef IMPALA_UDF_EXPORT
+#define IMPALA_UDF_EXPORT __attribute__ ((visibility ("default")))
+#endif
+
+#endif

--- a/hyperloglog-uda.cc
+++ b/hyperloglog-uda.cc
@@ -19,6 +19,8 @@
 #include <iostream>
 #include <impala_udf/udf.h>
 
+#include "common.h"
+
 using namespace std;
 using namespace impala_udf;
 
@@ -31,6 +33,7 @@ using namespace impala_udf;
 // Precision taken from the paper. Doesn't seem to matter very much when between [6,12]
 const int HLL_PRECISION = 10;
 
+IMPALA_UDF_EXPORT
 void HllInit(FunctionContext* ctx, StringVal* dst) {
   int str_len = pow(2, HLL_PRECISION);
   dst->ptr = ctx->Allocate(str_len);
@@ -60,6 +63,7 @@ static uint64_t Hash(const IntVal& v) {
   return FnvHash(&v.val, sizeof(int32_t), FNV64_SEED);
 }
 
+IMPALA_UDF_EXPORT
 void HllUpdate(FunctionContext* ctx, const IntVal& src, StringVal* dst) {
   if (src.is_null) return;
   assert(dst != NULL);
@@ -75,6 +79,7 @@ void HllUpdate(FunctionContext* ctx, const IntVal& src, StringVal* dst) {
   }
 }
 
+IMPALA_UDF_EXPORT
 void HllMerge(FunctionContext* ctx, const StringVal& src, StringVal* dst) {
   assert(dst != NULL);
   if (src.is_null || dst->is_null) return;
@@ -85,6 +90,7 @@ void HllMerge(FunctionContext* ctx, const StringVal& src, StringVal* dst) {
   }
 }
 
+IMPALA_UDF_EXPORT
 const StringVal HllSerialize(FunctionContext* ctx, const StringVal& src) {
   if (src.is_null) return StringVal::null();
   // Copy intermediate state into memory owned by Impala and free allocated memory
@@ -94,6 +100,7 @@ const StringVal HllSerialize(FunctionContext* ctx, const StringVal& src) {
   return result;
 }
 
+IMPALA_UDF_EXPORT
 StringVal HllFinalize(FunctionContext* ctx, const StringVal& src) {
   if (src.is_null) return StringVal::null();
   assert(src.len == pow(2, HLL_PRECISION));

--- a/uda-sample.cc
+++ b/uda-sample.cc
@@ -16,6 +16,8 @@
 #include <assert.h>
 #include <sstream>
 
+#include "common.h"
+
 using namespace impala_udf;
 using namespace std;
 
@@ -38,20 +40,24 @@ StringVal ToStringVal<DoubleVal>(FunctionContext* context, const DoubleVal& val)
 // ---------------------------------------------------------------------------
 // This is a sample of implementing a COUNT aggregate function.
 // ---------------------------------------------------------------------------
+IMPALA_UDF_EXPORT
 void CountInit(FunctionContext* context, BigIntVal* val) {
   val->is_null = false;
   val->val = 0;
 }
 
+IMPALA_UDF_EXPORT
 void CountUpdate(FunctionContext* context, const IntVal& input, BigIntVal* val) {
   if (input.is_null) return;
   ++val->val;
 }
 
+IMPALA_UDF_EXPORT
 void CountMerge(FunctionContext* context, const BigIntVal& src, BigIntVal* dst) {
   dst->val += src.val;
 }
 
+IMPALA_UDF_EXPORT
 BigIntVal CountFinalize(FunctionContext* context, const BigIntVal& val) {
   return val;
 }
@@ -65,6 +71,7 @@ struct AvgStruct {
 };
 
 // Initialize the StringVal intermediate to a zero'd AvgStruct
+IMPALA_UDF_EXPORT
 void AvgInit(FunctionContext* context, StringVal* val) {
   val->ptr = context->Allocate(sizeof(AvgStruct));
   // Exit on failed allocation. Impala will fail the query after some time.
@@ -77,6 +84,7 @@ void AvgInit(FunctionContext* context, StringVal* val) {
   memset(val->ptr, 0, val->len);
 }
 
+IMPALA_UDF_EXPORT
 void AvgUpdate(FunctionContext* context, const DoubleVal& input, StringVal* val) {
   if (input.is_null) return;
   // Handle failed allocation. Impala will fail the query after some time.
@@ -87,6 +95,7 @@ void AvgUpdate(FunctionContext* context, const DoubleVal& input, StringVal* val)
   ++avg->count;
 }
 
+IMPALA_UDF_EXPORT
 void AvgMerge(FunctionContext* context, const StringVal& src, StringVal* dst) {
   if (src.is_null || dst->is_null) return;
   const AvgStruct* src_avg = reinterpret_cast<const AvgStruct*>(src.ptr);
@@ -100,6 +109,7 @@ void AvgMerge(FunctionContext* context, const StringVal& src, StringVal* dst) {
 // and free the original allocation. Note that memory allocated by the StringVal ctor is
 // not necessarily persisted across UDA function calls, which is why we don't use it in
 // AvgInit().
+IMPALA_UDF_EXPORT
 StringVal AvgSerialize(FunctionContext* context, const StringVal& val) {
   if (val.is_null) return StringVal::null();
   // Copy the value into Impala-managed memory with StringVal::CopyFrom().
@@ -110,6 +120,7 @@ StringVal AvgSerialize(FunctionContext* context, const StringVal& val) {
   return result;
 }
 
+IMPALA_UDF_EXPORT
 StringVal AvgFinalize(FunctionContext* context, const StringVal& val) {
   if (val.is_null) return StringVal::null();
   assert(val.len == sizeof(AvgStruct));
@@ -132,10 +143,12 @@ StringVal AvgFinalize(FunctionContext* context, const StringVal& val) {
 // Delimiter to use if the separator is NULL.
 static const StringVal DEFAULT_STRING_CONCAT_DELIM((uint8_t*)", ", 2);
 
+IMPALA_UDF_EXPORT
 void StringConcatInit(FunctionContext* context, StringVal* val) {
   val->is_null = true;
 }
 
+IMPALA_UDF_EXPORT
 void StringConcatUpdate(FunctionContext* context, const StringVal& str,
     const StringVal& separator, StringVal* result) {
   if (str.is_null) return;
@@ -167,6 +180,7 @@ void StringConcatUpdate(FunctionContext* context, const StringVal& str,
   result->len += str.len;
 }
 
+IMPALA_UDF_EXPORT
 void StringConcatMerge(FunctionContext* context, const StringVal& src, StringVal* dst) {
   if (src.is_null) return;
   StringConcatUpdate(context, src, ",", dst);
@@ -177,6 +191,7 @@ void StringConcatMerge(FunctionContext* context, const StringVal& src, StringVal
 // StringVal, and free the intermediate's memory. Note that memory allocated by the
 // StringVal ctor is not necessarily persisted across UDA function calls, which is why we
 // don't use it in StringConcatUpdate().
+IMPALA_UDF_EXPORT
 StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val) {
   if (val.is_null) return val;
   // Copy the value into Impala-managed memory with StringVal::CopyFrom().
@@ -188,6 +203,7 @@ StringVal StringConcatSerialize(FunctionContext* context, const StringVal& val) 
 }
 
 // Same as StringConcatSerialize().
+IMPALA_UDF_EXPORT
 StringVal StringConcatFinalize(FunctionContext* context, const StringVal& val) {
   if (val.is_null) return val;
   // Copy the value into Impala-managed memory with StringVal::CopyFrom().

--- a/udf-sample.cc
+++ b/udf-sample.cc
@@ -18,14 +18,17 @@
 #include <cmath>
 #include <string>
 
+#include "common.h"
+
 // In this sample we are declaring a UDF that adds two ints and returns an int.
+IMPALA_UDF_EXPORT
 IntVal AddUdf(FunctionContext* context, const IntVal& arg1, const IntVal& arg2) {
   if (arg1.is_null || arg2.is_null) return IntVal::null();
   return IntVal(arg1.val + arg2.val);
 }
 
 // Multiple UDFs can be defined in the same file
-
+IMPALA_UDF_EXPORT
 BooleanVal FuzzyEquals(FunctionContext* ctx, const DoubleVal& x, const DoubleVal& y) {
   const double EPSILON = 0.000001f;
   if (x.is_null || y.is_null) return BooleanVal::null();
@@ -35,6 +38,7 @@ BooleanVal FuzzyEquals(FunctionContext* ctx, const DoubleVal& x, const DoubleVal
 
 // Check if the input string has any occurrences of the letters (a,e,i,o,u).
 // Case-insensitive, so also detects (A,E,I,O,U).
+IMPALA_UDF_EXPORT
 BooleanVal HasVowels(FunctionContext* context, const StringVal& input) {
   if (input.is_null) return BooleanVal::null();
 
@@ -52,6 +56,7 @@ BooleanVal HasVowels(FunctionContext* context, const StringVal& input) {
 
 // Count all occurrences of the letters (a,e,i,o,u) in the input string.
 // Case-insensitive, so also counts (A,E,I,O,U).
+IMPALA_UDF_EXPORT
 IntVal CountVowels(FunctionContext* context, const StringVal& arg1) {
   if (arg1.is_null) return IntVal::null();
 
@@ -70,6 +75,7 @@ IntVal CountVowels(FunctionContext* context, const StringVal& arg1) {
 
 // Remove all occurrences of the letters (a,e,i,o,u) from the input string.
 // Case-insensitive, so also removes (A,E,I,O,U).
+IMPALA_UDF_EXPORT
 StringVal StripVowels(FunctionContext* context, const StringVal& arg1) {
   if (arg1.is_null) return StringVal::null();
 
@@ -99,6 +105,7 @@ StringVal StripVowels(FunctionContext* context, const StringVal& arg1) {
 // In the prepare function, allocate an IntVal and set it as the shared state. This
 // IntVal will be set to the result to be returned, i.e. the argument if it's constant
 // and null otherwise.
+IMPALA_UDF_EXPORT
 void ReturnConstantArgPrepare(
     FunctionContext* context, FunctionContext::FunctionStateScope scope) {
   // UDFs should check the version to avoid unimplemented functions from being called
@@ -124,6 +131,7 @@ void ReturnConstantArgPrepare(
 }
 
 // Retreives and returns the shared state set in the prepare function
+IMPALA_UDF_EXPORT
 IntVal ReturnConstantArg(FunctionContext* context, const IntVal& const_val) {
   IntVal* state = reinterpret_cast<IntVal*>(
       context->GetFunctionState(FunctionContext::THREAD_LOCAL));
@@ -131,6 +139,7 @@ IntVal ReturnConstantArg(FunctionContext* context, const IntVal& const_val) {
 }
 
 // Cleans up the shared state
+IMPALA_UDF_EXPORT
 void ReturnConstantArgClose(
     FunctionContext* context, FunctionContext::FunctionStateScope scope) {
   if (scope == FunctionContext::THREAD_LOCAL) {


### PR DESCRIPTION
This is a parallel change to IMPALA-8187.

I tested it out by running the test binaries and also by loading the
UDF shared object into an Impala instance and making sure I could create
a UDF referencing one of the exported symbols by loading both the
.so and .ll versions of the UDFs.